### PR TITLE
[POC] Refactor requests in a separate class for readability and maintainability

### DIFF
--- a/lib/shinseibank/cli/account.rb
+++ b/lib/shinseibank/cli/account.rb
@@ -22,6 +22,7 @@ class ShinseiBank
         shinsei_bank.get_history(from: from, to: to, id: account_id).each do |tx|
           puts format_transaction(tx)
         end
+        logout
       end
 
       private

--- a/lib/shinseibank/request.rb
+++ b/lib/shinseibank/request.rb
@@ -1,0 +1,77 @@
+class ShinseiBank
+  class Request
+    URL = "https://pdirect04.shinseibank.com/FLEXCUBEAt/LiveConnect.dll".freeze
+    USER_AGENT = "Mozilla/5.0 (Windows; U; Windows NT 5.1;) PowerDirectBot/0.1".freeze
+
+    attr_reader :type, :data, :response
+
+    def initialize(type, data = {})
+      unless client.respond_to?(type)
+        raise ArgumentError, "Invalid request type: #{type}"
+      end
+      @type = type
+      @data = data
+    end
+
+    def perform
+      @response = client.public_send(type, URL, data)
+      response_data
+    end
+
+    def response_data
+      js_code_match = body.lines.first.
+        match(/(?<=<script language="JavaScript">).*(?=<\/script>)/)
+
+      return {} unless js_code_match
+
+      js_code_match[0].to_enum(:scan, (/(\w+)(?:\[(\d+)\])?=(.*?)(?=;)/)).
+        inject({}) do |data|
+
+        key, index, value = Regexp.last_match.captures
+
+        value = parse_value(value)
+
+        if index
+          data[key] ||= []
+          data[key][index.to_i] = value
+        else
+          data[key] = value
+        end
+
+        data
+      end
+    end
+
+    private
+
+      def client
+        @_client ||= HTTPClient.new(agent_name: USER_AGENT)
+      end
+
+      def body
+        @response.body
+      end
+
+      def parse_value(value)
+        if value == "new Array()"
+          []
+        else
+          match_numeric(match_string(value))
+        end
+      end
+
+      def match_string(value)
+        value.match(/^('|"|)(.*)\1$/)[2]
+      end
+
+      def match_numeric(value)
+        match = value.match /^\d{1,3}(,\d{3})*(\.\d*)?$/
+        return value unless match
+        if match[2]
+          value.tr(",", "").to_f
+        else
+          value.tr(",", "").to_i
+        end
+      end
+  end
+end

--- a/lib/shinseibank/request.rb
+++ b/lib/shinseibank/request.rb
@@ -14,32 +14,7 @@ class ShinseiBank
     end
 
     def perform
-      @response = client.public_send(type, URL, data)
-      response_data
-    end
-
-    def response_data
-      js_code_match = body.lines.first.
-        match(/(?<=<script language="JavaScript">).*(?=<\/script>)/)
-
-      return {} unless js_code_match
-
-      js_code_match[0].to_enum(:scan, (/(\w+)(?:\[(\d+)\])?=(.*?)(?=;)/)).
-        inject({}) do |data|
-
-        key, index, value = Regexp.last_match.captures
-
-        value = parse_value(value)
-
-        if index
-          data[key] ||= []
-          data[key][index.to_i] = value
-        else
-          data[key] = value
-        end
-
-        data
-      end
+      Response.new(client.public_send(type, URL, encoded_data))
     end
 
     private
@@ -48,30 +23,12 @@ class ShinseiBank
         @_client ||= HTTPClient.new(agent_name: USER_AGENT)
       end
 
-      def body
-        @response.body
-      end
-
-      def parse_value(value)
-        if value == "new Array()"
-          []
-        else
-          match_numeric(match_string(value))
-        end
-      end
-
-      def match_string(value)
-        value.match(/^('|"|)(.*)\1$/)[2]
-      end
-
-      def match_numeric(value)
-        match = value.match /^\d{1,3}(,\d{3})*(\.\d*)?$/
-        return value unless match
-        if match[2]
-          value.tr(",", "").to_f
-        else
-          value.tr(",", "").to_i
-        end
+      def encoded_data
+        data.map do |pair|
+          pair.map do |value|
+            value.dup.to_s.force_encoding(Encoding::ASCII_8BIT)
+          end
+        end.to_h
       end
   end
 end

--- a/lib/shinseibank/response.rb
+++ b/lib/shinseibank/response.rb
@@ -1,0 +1,78 @@
+require "kconv"
+
+class ShinseiBank
+  class Response < SimpleDelegator
+    def initialize(net_response)
+      @net_response = net_response
+      super
+    end
+
+    def body
+      # #toutf8 converts half-width Katakana to full-width (???)
+      # As recommended in the official Ruby documentation (see link below),
+      # we'll use this instead.
+      # https://docs.ruby-lang.org/ja/2.4.0/method/Kconv/m/toutf8.html
+      NKF.nkf("-wxm0", net_response.body)
+    end
+
+    def js_data
+      @_js_data ||= js_setup_code.
+        to_enum(:scan, js_var_assign_regex).
+        inject({}) do |variables|
+
+          name, index, value = Regexp.last_match.captures
+
+          value = parse_js_value(value)
+
+          if index
+            variables[name] ||= []
+            variables[name][index.to_i] = value
+          else
+            variables[name] = value
+          end
+
+          variables
+        end
+    end
+
+    private
+
+      attr_reader :net_response
+
+      def js_snippet_regex
+        /(?<=<script language="JavaScript">).*(?=<\/script>)/
+      end
+
+      def js_var_assign_regex
+        /(\w+)(?:\[(\d+)\])?=(.*?)(?=;)/
+      end
+
+      def js_setup_code
+        @_js_setup_code ||= body.lines.first.
+          match(js_snippet_regex).
+          to_a.fetch(0, "")
+      end
+
+      def parse_js_value(value)
+        if value == "new Array()"
+          []
+        else
+          match_numeric(match_string(value))
+        end
+      end
+
+      def match_string(value)
+        value.match(/^('|"|)(.*)\1$/)[2]
+      end
+
+      def match_numeric(value)
+        match = value.match /^\d{1,3}(,\d{3})*(\.\d*)?$/
+        return value unless match
+        if match[2]
+          value.tr(",", "").to_f
+        else
+          value.tr(",", "").to_i
+        end
+      end
+  end
+end

--- a/shinseibank.gemspec
+++ b/shinseibank.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "activesupport", "~> 5.1.1"
   spec.add_runtime_dependency "thor", "~> 0.19.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
- I defined `Request` and `Response` objects to isolate the code related to sending requests to and receiving responses from Shinsei's website.
- It allows me to isolate the encoding issues:
  * `Request` is responsible for encoding data properly before sending it to Shinsei (force encoding to ASCII-8BIT seems to do the trick).
  * `Response` is responsible for providing UTF-8 data to the rest of the application.
- The encoding relies on a trick that I first found in an old version of the official Ruby documentation: 
  > **Note** This method decode MIME encoded string and convert halfwidth katakana to fullwidth katakana. If you don't want it, use NKF.nkf('-wxm0', str).

  Source: [`String#toutf8` in Ruby 1.8.6](https://ruby-doc.org/stdlib-1.8.6/libdoc/nkf/rdoc/String.html#method-i-toutf8)
  Turns out the same comment is still present in the [Japanese Ruby 2.4.0 documentation](https://docs.ruby-lang.org/ja/2.4.0/method/Kconv/m/toutf8.html).
- I did not touch all the methods related to fundings, and I'd suggest removing them until we get some incentive to maintain them.
- Issuing a transfer works. 
- Displaying history works, with a minor display bug on strings length. 